### PR TITLE
Support custom query streams

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "attrs==16.3.0",
         "pendulum>=1.2.0",
         "singer-python==5.9.0",
-        "pymssql>=2.2.1",
+        "pymssql>=2.2.5",
         "backoff==1.8.0",
     ],
     entry_points="""

--- a/tap_mssql/sync_strategies/common.py
+++ b/tap_mssql/sync_strategies/common.py
@@ -63,6 +63,11 @@ def get_database_name(catalog_entry):
     return md_map.get((), {}).get("database-name")
 
 
+def get_custom_filter(catalog_entry):
+    md_map = metadata.to_map(catalog_entry.metadata)
+    return md_map.get((), {}).get("custom-filter")
+
+
 def get_key_properties(catalog_entry):
     catalog_metadata = metadata.to_map(catalog_entry.metadata)
     stream_metadata = catalog_metadata.get((), {})
@@ -84,6 +89,10 @@ def generate_select_sql(catalog_entry, columns):
     escaped_columns = [escape(c) for c in columns]
 
     select_sql = "SELECT {} FROM {}.{}".format(",".join(escaped_columns), escaped_db, escaped_table)
+
+    custom_filter = get_custom_filter(catalog_entry)
+    if custom_filter:
+        select_sql = "{} WHERE {}".format(select_sql, custom_filter)
 
     # escape percent signs
     select_sql = select_sql.replace("%", "%%")

--- a/tap_mssql/sync_strategies/incremental.py
+++ b/tap_mssql/sync_strategies/incremental.py
@@ -55,8 +55,11 @@ def sync_table(mssql_conn, config, catalog_entry, state, columns):
                 if catalog_entry.schema.properties[replication_key_metadata].format == "date-time":
                     replication_key_value = pendulum.parse(replication_key_value)
 
-                select_sql += " WHERE \"{}\" >= %(replication_key_value)s ORDER BY \"{}\" ASC".format(
-                    replication_key_metadata, replication_key_metadata
+                has_custom_filter = bool(stream_metadata.get("custom-filter"))
+                separator = "AND" if has_custom_filter else "WHERE"
+
+                select_sql += " {} \"{}\" >= %(replication_key_value)s ORDER BY \"{}\" ASC".format(
+                    separator, replication_key_metadata, replication_key_metadata
                 )
 
                 params["replication_key_value"] = replication_key_value


### PR DESCRIPTION
Example Meltano config:
```
select:
  - dbo-inventory.*
  - dbo-inventory__custom.*
config:
  custom_streams:
    - custom_stream: dbo-inventory__custom
      base_stream: dbo-inventory
metadata:
  dbo-inventory__custom:
    replication-method: FULL_TABLE
    custom-filter: quantity > 150
  dbo-inventory:
    replication-method: FULL_TABLE
```

Example Meltano config with incremental replication method (when using `target-bigquery` remember to also set `replication_method: incremental`):
```
select:
  - dbo-inventory.*
  - dbo-inventory__custom.*
config:
  custom_streams:
    - custom_stream: dbo-inventory__custom
      base_stream: dbo-inventory
metadata:
  dbo-inventory__custom:
    replication-method: INCREMENTAL
    custom-filter: quantity > 150
    replication-key: id
    table-key-properties:
      - id
  dbo-inventory:
    replication-method: INCREMENTAL
    replication-key: id
    table-key-properties:
      - id
```